### PR TITLE
Corpus crawl branch

### DIFF
--- a/src/main/java/cc/twittertools/download/AsyncEmbeddedJsonStatusBlockCrawler.java
+++ b/src/main/java/cc/twittertools/download/AsyncEmbeddedJsonStatusBlockCrawler.java
@@ -408,10 +408,8 @@ public class AsyncEmbeddedJsonStatusBlockCrawler {
     DirectoryManager dm = new DirectoryManager(cmdline.getOptionValue(DATA_OPTION), cmdline.getOptionValue(OUTPUT_OPTION));
     dm.createDocumentList();
     String currentFile = dm.getNextDoc();
-    while(currentFile != null) {
-      //String outputFile = output + currentFile.substring(currentFile.lastIndexOf("/"));
+    while (currentFile != null) {
       String outputFile = currentFile.replace(data, output);
-      //new AsyncEmbeddedJsonStatusBlockCrawler(new File(data), output, repair, noFollow).fetch();
       new AsyncEmbeddedJsonStatusBlockCrawler(new File(currentFile), outputFile, repair, noFollow).fetch();
     }
   }

--- a/src/main/java/cc/twittertools/download/DirectoryManager.java
+++ b/src/main/java/cc/twittertools/download/DirectoryManager.java
@@ -1,28 +1,27 @@
-/*
- *    Copyright (c) Sematext International
- *    All Rights Reserved
- *
- *    THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF Sematext International
- *    The copyright notice above does not evidence any
- *    actual or intended publication of such source code.
- */
-
 package cc.twittertools.download;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 public class DirectoryManager {
-  private String absolutePath;
-  private String outputPath;
+  private static final Logger LOG = Logger.getLogger(DirectoryManager.class);
+  
+  private final String absolutePath;
+  private final String outputPath;
   private int docCount = 0;
   private int currentDocIndex = 0;
   private ArrayList docList;
 
   public DirectoryManager(String absolutePath, String outputPath) {
-    this.absolutePath = absolutePath;
-    this.outputPath = outputPath;
-    this.docList = new ArrayList<String>();
+    this.absolutePath = Preconditions.checkNotNull(absolutePath);
+    this.outputPath = Preconditions.checkNotNull(outputPath);
+    this.docList = Lists.newArrayList();
   }
 
   /**
@@ -32,7 +31,7 @@ public class DirectoryManager {
     File curDir = new File(this.absolutePath);
     String[] curFiles = curDir.list();
     this.elaborateFolder(curFiles, this.absolutePath, this.outputPath);
-    System.out.println("Document list loaded: " + this.docList.size() + " elements.");
+    LOG.info("Document list loaded: " + this.docList.size() + " elements.");
   }
 
   /**
@@ -45,18 +44,19 @@ public class DirectoryManager {
       }
       File curFile = new File(curPath + files[i]);
       
-      if(curPath.compareTo(this.absolutePath) == 0 && !curFile.isDirectory()) continue;
+      if (curPath.compareTo(this.absolutePath) == 0 && !curFile.isDirectory()) {
+        continue;
+      }
       
-      //if (curFile.isDirectory() && curFile.getName().startsWith("2011")) {
       if (curFile.isDirectory()) {
         String[] folderFiles = curFile.list();
         
-        String CurFolder = curOutPath + files[i] + "/"; 
-        File OD = new File(CurFolder); 
-        boolean A = OD.mkdir();
+        String curFolder = curOutPath + files[i] + "/"; 
+        File oD = new File(curFolder); 
+        boolean a = oD.mkdir();
         
         this.elaborateFolder(folderFiles, curPath + files[i] + "/", curOutPath + files[i] + "/");
-      } else if(curPath.compareTo(this.absolutePath) != 0) {
+      } else if (curPath.compareTo(this.absolutePath) != 0) {
         this.docList.add(this.docList.size(), curFile.getAbsolutePath());
       }
     }
@@ -67,11 +67,16 @@ public class DirectoryManager {
    * Get the next document to elaborate
    */
   public synchronized String getNextDoc() {
-    if(this.currentDocIndex == this.docList.size()) return null;
-      String nextDocName = (String) this.docList.get(new Integer(this.currentDocIndex));
+    if (this.currentDocIndex == this.docList.size()) {
+      return null;
+    }
+    
+    String nextDocName = (String) this.docList.get(new Integer(this.currentDocIndex));
+    
     if (nextDocName == null) {
       return null;
     }
+    
     this.currentDocIndex++;
     return nextDocName;
   }
@@ -79,7 +84,7 @@ public class DirectoryManager {
   /**
    * Debug methods to explore the produced HashMaps
    */
-  public ArrayList<String> getDocList() {
+  public List<String> getDocList() {
     return this.docList;
   }
 }


### PR DESCRIPTION
I have added a branch called "corpus_crawl" that permits to crawl the entire twitter corpus by running the script only one time.
It uses the "-data" parameter as root directory of the corpus, and the "-output" parameter as the output root folder.
The script replicates, in the output folder, the same directory structure of the original corpus.
