### PR TITLE
Handle the nbsp character to fix the detection of valid URLs (inc. test)...

### DIFF
--- a/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
+++ b/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
@@ -62,6 +62,17 @@ public final class LowerCaseEntityPreservingFilter extends TokenFilter {
       tailBufferSaved = null;
     }
 
+    // Check for additional whitespace chars
+    for (int i = 0; i < termAtt.length(); i++) {
+      if (isWhiteSpace(i)) {
+        // Remove the tail of the string from the buffer and save it
+        // for the next iteration
+        tailBuffer = Arrays.copyOfRange(buffer, i + 1, termAtt.length());
+        termAtt.setLength(i);
+        break;
+      }
+    }
+
     int entityType = isEntity(termAtt.toString());
     if (entityType == VALID_URL) {
       keywordAttr.setKeyword(true);
@@ -240,6 +251,19 @@ public final class LowerCaseEntityPreservingFilter extends TokenFilter {
     case '\uFF03': // Unicode #
     case '_':
       return true;
+    }
+    return false;
+  }
+
+  /**
+   * Check if the character at position i in the buffer is a whitespace
+   * which Character.isWhitespace skips over (e.g: nbsp)
+   */
+  public boolean isWhiteSpace(int i) {
+    final char[] buffer = termAtt.buffer();
+    switch (buffer[i]) {
+      case '\u00A0': // Unicode nbsp
+        return true;
     }
     return false;
   }

--- a/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
+++ b/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
@@ -265,6 +265,7 @@ public final class LowerCaseEntityPreservingFilter extends TokenFilter {
       case '\u00A0': // Unicode nbsp
       case '\u2007':
       case '\u202f':
+      case '…':
         return true;
     }
     return false;

--- a/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
+++ b/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
@@ -265,7 +265,6 @@ public final class LowerCaseEntityPreservingFilter extends TokenFilter {
       case '\u00A0': // Unicode nbsp
       case '\u2007':
       case '\u202f':
-      case '…':
         return true;
     }
     return false;

--- a/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
+++ b/twitter-tools-core/src/main/java/cc/twittertools/index/LowerCaseEntityPreservingFilter.java
@@ -256,13 +256,15 @@ public final class LowerCaseEntityPreservingFilter extends TokenFilter {
   }
 
   /**
-   * Check if the character at position i in the buffer is a whitespace
-   * which Character.isWhitespace skips over (e.g: nbsp)
+   * Check if the character at position i in the buffer is whitespace,
+   * which Character.isWhitespace does not define (i.e: non-breaking spaces)
    */
   public boolean isWhiteSpace(int i) {
     final char[] buffer = termAtt.buffer();
     switch (buffer[i]) {
       case '\u00A0': // Unicode nbsp
+      case '\u2007':
+      case '\u202f':
         return true;
     }
     return false;

--- a/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
+++ b/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
@@ -59,6 +59,8 @@ public class TokenizationTest {
   Object[][] nbspExamples = new Object[][] {
       {"@Porsche : 2014 is already here #zebracar #LM24 http://bit.ly/18RUczp\u00a0 pic.twitter.com/cQ7z0c2hMg",
        new String[] {"@porsche", "2014", "is", "alreadi", "here", "#zebracar", "#lm24", "http://bit.ly/18RUczp", "pic.twitter.com/cQ7z0c2hMg"}},
+      {"Some cars are in the river #NBC4NY http://t.co/WmK9Hc…",
+       new String[] {"some", "car", "ar", "in", "the", "river", "#nbc4ny", "http://t.co/WmK9Hc"}}
   };
   
   @Test

--- a/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
+++ b/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
@@ -55,6 +55,11 @@ public class TokenizationTest {
       {"this][is[lots[(of)words+with-lots=of-strange!characters?$in-fact=it&has&Every&Single:one;of<them>in_here_B&N_test_test?test\\test^testing`testing{testing}testing…testing¬testing·testing what?",
        new String[] {"thi", "is", "lot", "of", "word", "with", "lot", "of", "strang", "charact", "in", "fact", "it", "ha", "everi", "singl", "on", "of", "them", "in", "here", "bn", "test", "test", "test", "test", "test", "test", "test", "test", "test", "test", "test", "what"}},
   };
+
+  Object[][] nbspExamples = new Object[][] {
+      {"@Porsche : 2014 is already here #zebracar #LM24 http://bit.ly/18RUczp\u00a0 pic.twitter.com/cQ7z0c2hMg",
+       new String[] {"@porsche", "2014", "is", "alreadi", "here", "#zebracar", "#lm24", "http://bit.ly/18RUczp", "pic.twitter.com/cQ7z0c2hMg"}},
+  };
   
   @Test
   public void basic() throws Exception {
@@ -62,6 +67,15 @@ public class TokenizationTest {
 
     for (int i = 0; i < examples.length; i++) {
       verify((String[]) examples[i][1], parseKeywords(analyzer, (String) examples[i][0]));
+    }
+  }
+
+  @Test
+  public void nbsp() throws Exception {
+    Analyzer analyzer = new TweetAnalyzer(Version.LUCENE_43);
+
+    for (int i = 0; i < nbspExamples.length; i++) {
+      verify((String[]) nbspExamples[i][1], parseKeywords(analyzer, (String) nbspExamples[i][0]));
     }
   }
 

--- a/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
+++ b/twitter-tools-core/src/test/java/cc/twittertools/index/TokenizationTest.java
@@ -59,8 +59,6 @@ public class TokenizationTest {
   Object[][] nbspExamples = new Object[][] {
       {"@Porsche : 2014 is already here #zebracar #LM24 http://bit.ly/18RUczp\u00a0 pic.twitter.com/cQ7z0c2hMg",
        new String[] {"@porsche", "2014", "is", "alreadi", "here", "#zebracar", "#lm24", "http://bit.ly/18RUczp", "pic.twitter.com/cQ7z0c2hMg"}},
-      {"Some cars are in the river #NBC4NY http://t.co/WmK9Hc…",
-       new String[] {"some", "car", "ar", "in", "the", "river", "#nbc4ny", "http://t.co/WmK9Hc"}}
   };
   
   @Test


### PR DESCRIPTION
....

WhitespaceTokenizer splits according to Java's Character.isWhitespace()
which excludes nbsp and breaks twitter-text detection/regex for valid URLs.